### PR TITLE
Change internal and admin urls

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -408,9 +408,7 @@ class KeystoneOperatorCharm(sunbeam_charm.OSBaseOperatorAPICharm):
     def admin_endpoint(self):
         admin_hostname = self.model.config.get('os-admin-hostname')
         if not admin_hostname:
-            admin_hostname = self.model.get_binding(
-                "identity-service"
-            ).network.ingress_address
+            admin_hostname = self.app.name
         admin_port = self.model.config['admin-port']
         return f'http://{admin_hostname}:{admin_port}'
 
@@ -418,9 +416,7 @@ class KeystoneOperatorCharm(sunbeam_charm.OSBaseOperatorAPICharm):
     def internal_endpoint(self):
         internal_hostname = self.model.config.get('os-internal-hostname')
         if not internal_hostname:
-            internal_hostname = self.model.get_binding(
-                "identity-service"
-            ).network.ingress_address
+            internal_hostname = self.app.name
         service_port = self.model.config['service-port']
         return f'http://{internal_hostname}:{service_port}'
 


### PR DESCRIPTION
Change internal and admin urls to point to
corresponding kubernetes service names
instead of IPs.