### PR TITLE
Add support for ingress-public

### DIFF
--- a/lib/charms/sunbeam_keystone_operator/v0/identity_service.py
+++ b/lib/charms/sunbeam_keystone_operator/v0/identity_service.py
@@ -310,6 +310,24 @@ class IdentityServiceRequires(Object):
         return self.get_remote_app_data('service-user-id')
 
 
+    @property
+    def internal_auth_url(self) -> str:
+        """Return the internal_auth_url."""
+        return self.get_remote_app_data('internal-auth-url')
+
+
+    @property
+    def admin_auth_url(self) -> str:
+        """Return the admin_auth_url."""
+        return self.get_remote_app_data('admin-auth-url')
+
+
+    @property
+    def public_auth_url(self) -> str:
+        """Return the public_auth_url."""
+        return self.get_remote_app_data('public-auth-url')
+
+
     def register_services(self, service_endpoints: dict,
                           region: str) -> None:
         """Request access to the IdentityService server."""
@@ -437,7 +455,10 @@ class IdentityServiceProvides(Object):
                                          service_domain: str,
                                          service_password: str,
                                          service_project: str,
-                                         service_user: str):
+                                         service_user: str,
+                                         internal_auth_url: str,
+                                         admin_auth_url: str,
+                                         public_auth_url: str):
         logging.debug("Setting identity_service connection information.")
         for relation in self.framework.model.relations[relation_name]:
             if relation.id == relation_id:
@@ -466,3 +487,6 @@ class IdentityServiceProvides(Object):
         app_data["service-user-name"] = service_user.name
         app_data["service-user-id"] = service_user.id
         app_data["service-password"] = service_password
+        app_data["internal-auth-url"] = internal_auth_url
+        app_data["admin-auth-url"] = admin_auth_url
+        app_data["public-auth-url"] = public_auth_url

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,8 +27,12 @@ requires:
   shared-db:
     interface: mysql_datastore
     limit: 1
-  ingress:
+  ingress-internal:
     interface: ingress
+    limit: 1
+  ingress-public:
+    interface: ingress
+    optional: true
     limit: 1
 
 peers:

--- a/src/templates/wsgi-keystone.conf.j2
+++ b/src/templates/wsgi-keystone.conf.j2
@@ -4,8 +4,8 @@ Listen 0.0.0.0:35357
 <VirtualHost *:5000>
     WSGIDaemonProcess keystone-public processes=1 threads=1 user=keystone group=keystone display-name=%{GROUP} python-path=/usr/lib/python3/site-packages
     WSGIProcessGroup keystone-public
-    {% if ingress.ingress_path -%}
-    WSGIScriptAlias {{ ingress.ingress_path }} /usr/bin/keystone-wsgi-public
+    {% if ingress_internal.ingress_path -%}
+    WSGIScriptAlias {{ ingress_internal.ingress_path }} /usr/bin/keystone-wsgi-public
     {% endif -%}
     WSGIScriptAlias / /usr/bin/keystone-wsgi-public
     WSGIApplicationGroup %{GLOBAL}

--- a/unit_tests/test_keystone_charm.py
+++ b/unit_tests/test_keystone_charm.py
@@ -138,9 +138,11 @@ class TestKeystoneOperatorCharm(test_utils.CharmTestCase):
         rel_data = self.harness.get_relation_data(
             identity_rel_id,
             self.harness.charm.unit.app.name)
+        self.maxDiff = None
         self.assertEqual(
             rel_data,
             {
+                'admin-auth-url': 'http://10.0.0.10:35357',
                 'admin-domain-id': 'adomain_id',
                 'admin-domain-name': 'adomain_name',
                 'admin-project-id': 'aproject_id',
@@ -151,9 +153,11 @@ class TestKeystoneOperatorCharm(test_utils.CharmTestCase):
                 'auth-host': '10.0.0.10',
                 'auth-port': '5000',
                 'auth-protocol': 'http',
+                'internal-auth-url': 'http://internal-url',
                 'internal-host': '10.0.0.10',
                 'internal-port': '5000',
                 'internal-protocol': 'http',
+                'public-auth-url': 'http://public-url',
                 'service-domain-id': 'sdomain_id',
                 'service-domain-name': 'sdomain_name',
                 'service-host': '10.0.0.10',


### PR DESCRIPTION
The patch has following changes:

* Change ingress relation to ingress-internal
* Add ingress-public relation in metadata
* Update keystone endpoints on ingress change
* Update identity_service library to include auth_urls
  so that other openstack charms can update keystone_authtoken
  section in configuration files with auth urls.